### PR TITLE
Support ua_based evaluations on user_field

### DIFF
--- a/src/main/java/com/statsig/androidlocalevalsdk/Evaluator.kt
+++ b/src/main/java/com/statsig/androidlocalevalsdk/Evaluator.kt
@@ -210,6 +210,10 @@ internal class Evaluator(private val specStore: Store, private val errorBoundary
                     value = EvaluatorUtils.getFromUser(user, field)
                 }
 
+                ConfigCondition.UA_BASED -> {
+                    value = EvaluatorUtils.getFromUser(user, field)
+                }
+
                 ConfigCondition.USER_FIELD -> {
                     value = EvaluatorUtils.getFromUser(user, field)
                 }


### PR DESCRIPTION
We cant do ip3 country or ua parser, but we can check the country/os_name field on the user object